### PR TITLE
Make YouTubeExtractor usable by RxJava

### DIFF
--- a/app/src/main/java/com/commit451/youtubeextractor/sample/MainActivity.java
+++ b/app/src/main/java/com/commit451/youtubeextractor/sample/MainActivity.java
@@ -74,7 +74,7 @@ public class MainActivity extends AppCompatActivity {
         }
     };
 
-    private YouTubeExtractor mExtractor;
+    private final YouTubeExtractor mExtractor = new YouTubeExtractor();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -84,8 +84,7 @@ public class MainActivity extends AppCompatActivity {
         mVideoView = (EMVideoView) findViewById(R.id.video_view);
         mDescription = (TextView) findViewById(R.id.description);
 
-        mExtractor = YouTubeExtractor.create();
-        mExtractor.extract(GRID_YOUTUBE_ID).enqueue(mExtractionCallback);
+        mExtractor.getYouTubeVideoData(GRID_YOUTUBE_ID).enqueue(mExtractionCallback);
         if (savedInstanceState != null) {
             mSavedPosition = savedInstanceState.getInt(STATE_SAVED_POSITION, 0);
         }

--- a/youtubeextractor/build.gradle
+++ b/youtubeextractor/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.mockito:mockito-core:1.9.5'
     compile 'com.android.support:support-annotations:23.4.0'
     compile 'com.squareup.retrofit2:retrofit:2.0.2'
 }

--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/BaseExtractor.java
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/BaseExtractor.java
@@ -1,0 +1,44 @@
+package com.commit451.youtubeextractor;
+
+import android.support.annotation.Nullable;
+
+import okhttp3.OkHttpClient;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+
+public abstract class BaseExtractor<T> {
+
+    private static final String BASE_URL = "https://www.youtube.com/";
+    static final int YOUTUBE_VIDEO_QUALITY_SMALL_240 = 36;
+    static final int YOUTUBE_VIDEO_QUALITY_MEDIUM_360 = 18;
+    static final int YOUTUBE_VIDEO_QUALITY_HD_720 = 22;
+    static final int YOUTUBE_VIDEO_QUALITY_HD_1080 = 37;
+
+    protected final T mYouTube;
+
+    private final YoutubeExtractorInterceptor mYoutubeExtractorInterceptor = new YoutubeExtractorInterceptor();
+
+    public BaseExtractor(Class<T> youTubeClass, OkHttpClient.Builder okBuilder,
+                         @Nullable CallAdapter.Factory callAdapterFactory) {
+
+        okBuilder.addInterceptor(mYoutubeExtractorInterceptor);
+
+        Retrofit.Builder retrofitBuilder = new Retrofit.Builder();
+
+        if (callAdapterFactory != null) {
+            retrofitBuilder.addCallAdapterFactory(callAdapterFactory);
+        }
+
+        retrofitBuilder
+            .baseUrl(BASE_URL)
+            .client(okBuilder.build())
+            .addConverterFactory(YouTubeExtractionConverterFactory.create());
+
+        mYouTube = retrofitBuilder.build().create(youTubeClass);
+    }
+
+    public void setLanguage(String language) {
+        mYoutubeExtractorInterceptor.setLanguage(language);
+    }
+
+}

--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/Constants.java
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/Constants.java
@@ -1,0 +1,8 @@
+package com.commit451.youtubeextractor;
+
+public interface Constants {
+
+    String INFO = "get_video_info?el=info&ps=default&gl=US";
+    String VIDEO_ID = "video_id";
+
+}

--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeDefault.java
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeDefault.java
@@ -1,0 +1,11 @@
+package com.commit451.youtubeextractor;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface YouTubeDefault {
+
+    @GET(Constants.INFO) Call<YouTubeExtractionResult> getYouTubeVideoData(@Query(Constants.VIDEO_ID) String videoId);
+
+}

--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.java
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.java
@@ -1,89 +1,20 @@
 package com.commit451.youtubeextractor;
 
-import android.support.annotation.NonNull;
-
-import java.util.Locale;
-
 import okhttp3.OkHttpClient;
 import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Retrofit;
-import retrofit2.http.GET;
-import retrofit2.http.Header;
-import retrofit2.http.Query;
 
 /**
  * Class that allows you to extract desired data from a YouTube video, such as streamable {@link android.net.Uri}s
  * given its video id, which is typically contained within the YouTube video url, ie. https://www.youtube.com/watch?v=dQw4w9WgXcQ
  * has a video id of dQw4w9WgXcQ
  */
-public class YouTubeExtractor {
+public class YouTubeExtractor extends BaseExtractor<YouTubeDefault> implements YouTubeDefault {
 
-    public static final int YOUTUBE_VIDEO_QUALITY_SMALL_240 = 36;
-    public static final int YOUTUBE_VIDEO_QUALITY_MEDIUM_360 = 18;
-    public static final int YOUTUBE_VIDEO_QUALITY_HD_720 = 22;
-    public static final int YOUTUBE_VIDEO_QUALITY_HD_1080 = 37;
-
-    private static final String EL_TYPE = "info";
-    private static final String PS_TYPE = "default";
-    private static final String GL_TYPE = "US";
-    /**
-     * Retrofit interface, which we use, but do not expose
-     */
-    interface YouTube {
-
-        @GET("get_video_info?el=" + EL_TYPE + "&ps=" + PS_TYPE + "&gl=" + GL_TYPE)
-        Call<YouTubeExtractionResult> getYouTubeVideoData(@Query("video_id") String videoId,
-                                                          @Query("language") String language,
-                                                          @Header("Accept-Language") String languageForHeader);
+    public YouTubeExtractor() {
+        super(YouTubeDefault.class, new OkHttpClient.Builder(), null);
     }
 
-    private YouTube mYouTube;
-    private String mLanguage;
-
-    /**
-     * Create a YouTubeExtractor
-     * @return a new {@link YouTubeExtractor}
-     */
-    public static YouTubeExtractor create() {
-        return create(new OkHttpClient());
-    }
-
-    /**
-     * Create a YouTubeExtractor, with a customly configured {@link OkHttpClient}
-     * @param okHttpClient a configured {@link OkHttpClient}
-     * @return a new {@link YouTubeExtractor}
-     */
-    public static YouTubeExtractor create(OkHttpClient okHttpClient) {
-        YouTubeExtractor extractor = new YouTubeExtractor();
-        Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl("https://www.youtube.com/")
-                .client(okHttpClient)
-                .addConverterFactory(YouTubeExtractionConverterFactory.create())
-                .build();
-        extractor.mYouTube = retrofit.create(YouTube.class);
-        extractor.mLanguage = Locale.getDefault().getLanguage();
-        return extractor;
-    }
-
-    private YouTubeExtractor() {
-        //Use the create method
-    }
-
-    /**
-     * Set the language. Defaults to {@link Locale#getDefault()}
-     * @param language the language
-     */
-    public void setLanguage(String language) {
-        mLanguage = language;
-    }
-
-    /**
-     * Extract the YouTube video data.
-     * @param videoId the id of the YouTube video, which can be found in the URL
-     * @return the Retrofit call, which you can call {@link Call#execute()} or {@link Call#enqueue(Callback)} on
-     */
-    public Call<YouTubeExtractionResult> extract(@NonNull String videoId) {
-        return mYouTube.getYouTubeVideoData(videoId, mLanguage, mLanguage);
+    @Override public Call<YouTubeExtractionResult> getYouTubeVideoData(String videoId) {
+        return mYouTube.getYouTubeVideoData(videoId);
     }
 }

--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YoutubeExtractorInterceptor.java
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YoutubeExtractorInterceptor.java
@@ -1,0 +1,43 @@
+package com.commit451.youtubeextractor;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+class YoutubeExtractorInterceptor implements Interceptor {
+
+    static final String ACCEPT_LANGUAGE_HEADER = "Accept-Language";
+    static final String LANGUAGE_QUERY_PARAM = "language";
+
+    @NonNull String mLanguage;
+
+    YoutubeExtractorInterceptor() {
+        this.mLanguage = Locale.getDefault().getLanguage();
+    }
+
+    @Override public Response intercept(Chain chain) throws IOException {
+
+        Request request = chain.request();
+
+        HttpUrl url = request.url()
+            .newBuilder()
+            .addQueryParameter(LANGUAGE_QUERY_PARAM, mLanguage)
+            .build();
+
+        Request requestWithHeaders = request.newBuilder()
+            .addHeader(ACCEPT_LANGUAGE_HEADER, mLanguage)
+            .url(url)
+            .build();
+        return chain.proceed(requestWithHeaders);
+    }
+
+    public void setLanguage(@NonNull String language) {
+        mLanguage = language;
+    }
+}

--- a/youtubeextractor/src/test/java/com/commit451/youtubeextractor/ExtractionTest.java
+++ b/youtubeextractor/src/test/java/com/commit451/youtubeextractor/ExtractionTest.java
@@ -18,8 +18,8 @@ public class ExtractionTest {
 
     @Test
     public void testExtraction() throws Exception {
-        YouTubeExtractor extractor = YouTubeExtractor.create();
-        Response<YouTubeExtractionResult> resultResponse = extractor.extract(GRID_YOUTUBE_ID).execute();
+        YouTubeExtractor extractor = new YouTubeExtractor();
+        Response<YouTubeExtractionResult> resultResponse = extractor.getYouTubeVideoData(GRID_YOUTUBE_ID).execute();
         TestUtil.assertRetrofitResponseSuccess(resultResponse);
         //Verified before that this ID should hold at least one video and image URI
 //        Uri bestVideoUri = resultResponse.body().getBestAvaiableQualityVideoUri();

--- a/youtubeextractor/src/test/java/com/commit451/youtubeextractor/InterceptorTest.java
+++ b/youtubeextractor/src/test/java/com/commit451/youtubeextractor/InterceptorTest.java
@@ -1,0 +1,67 @@
+package com.commit451.youtubeextractor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import okhttp3.Connection;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class InterceptorTest {
+
+    @Test public void testLanguage() throws Exception {
+        YoutubeExtractorInterceptor interceptor = new YoutubeExtractorInterceptor();
+        assertEquals(Locale.getDefault().getLanguage(), interceptor.mLanguage);
+        String language = "test language";
+        interceptor.setLanguage(language);
+        assertEquals(language, interceptor.mLanguage);
+    }
+
+    @Test public void testHeader() throws IOException {
+        YoutubeExtractorInterceptor interceptor = new YoutubeExtractorInterceptor();
+        RealChain requestFacade = new RealChain();
+        interceptor.intercept(requestFacade);
+        Headers headers = requestFacade.mHeaders;
+        assertEquals(1, headers.size());
+        assertEquals(Locale.getDefault().getLanguage(), headers.get(YoutubeExtractorInterceptor.ACCEPT_LANGUAGE_HEADER));
+    }
+
+    @Test public void testQueryParam() throws IOException {
+        YoutubeExtractorInterceptor interceptor = new YoutubeExtractorInterceptor();
+        RealChain requestFacade = new RealChain();
+        HttpUrl url = interceptor.intercept(requestFacade).request().url();
+        assertEquals(Locale.getDefault().getLanguage(), url.queryParameter(YoutubeExtractorInterceptor.LANGUAGE_QUERY_PARAM));
+    }
+
+    static class RealChain implements Interceptor.Chain {
+
+        Headers mHeaders;
+
+        @Override public Request request() {
+            return new Request.Builder().url("http://test.url/").build();
+        }
+
+        @Override public Response proceed(Request request) throws IOException {
+            mHeaders = request.headers();
+            return new Response.Builder().request(request).protocol(Protocol.SPDY_3).code(200).build();
+        }
+
+        @Override public Connection connection() {
+            return mock(Connection.class);
+        }
+    }
+}


### PR DESCRIPTION
Found this on r/androidDev today 😄 

- Refactor YouTubeExtractor to allow other call adapter factories. 
- Added an Interceptor for the `Accept-Language` header and `language` query param to simplify the rest interface.

To use RxJava:

```java
import com.commit451.youtubeextractor.Constants;
import com.commit451.youtubeextractor.YouTubeExtractionResult;

import retrofit2.http.GET;
import retrofit2.http.Query;
import rx.Observable;

public interface ObservableYouTube {

    @GET(Constants.INFO)
    Observable<YouTubeExtractionResult> getYouTubeVideoData(@Query(Constants.VIDEO_ID) String videoId);
    
}
```

```java
import com.commit451.youtubeextractor.BaseExtractor;
import com.commit451.youtubeextractor.YouTubeExtractionResult;

import okhttp3.OkHttpClient;
import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
import rx.Observable;
import rx.Scheduler;
import rx.schedulers.Schedulers;

public class ObservableYouTubeExtractor extends BaseExtractor<ObservableYouTube> implements ObservableYouTube {

    public ObservableYouTubeExtractor() {
        this(new OkHttpClient.Builder(), Schedulers.io());
    }

    public ObservableYouTubeExtractor(OkHttpClient.Builder okHttpClientBuilder, Scheduler scheduler) {
        super(ObservableYouTube.class, okHttpClientBuilder, RxJavaCallAdapterFactory.createWithScheduler(scheduler));
    }

    @Override public Observable<YouTubeExtractionResult> getYouTubeVideoData(String videoId) {
        return mYouTube.getYouTubeVideoData(videoId);
    }
}
```