### PR TITLE
viewCountFromHtml can ignore exceptions

### DIFF
--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.kt
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.kt
@@ -118,7 +118,9 @@ class YouTubeExtractor private constructor(builder: Builder) {
     }
 
     private fun viewCountFromHtml(doc: Document): Long? {
-        return doc.select("meta[itemprop=interactionCount]").attr("content").toLong()
+        return tryIgnoringException {
+            doc.select("meta[itemprop=interactionCount]").attr("content").toLong()
+        }
     }
 
     private fun tryIgnoringException(block: () -> String): String? {


### PR DESCRIPTION
Sometimes YouTube returns a strange mostly empty page that is missing the view count.

This change makes `viewCountFromHtml` to be consistent with the other `FromHtml` functions and allows exceptions to be ignored.

Solves https://github.com/Commit451/YouTubeExtractor/issues/47