### PR TITLE
make tryIgnoringException generic

### DIFF
--- a/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.kt
+++ b/youtubeextractor/src/main/java/com/commit451/youtubeextractor/YouTubeExtractor.kt
@@ -123,7 +123,7 @@ class YouTubeExtractor private constructor(builder: Builder) {
         }
     }
 
-    private fun tryIgnoringException(block: () -> String): String? {
+    private fun <T>tryIgnoringException(block: () -> T): T? {
         try {
             return block.invoke()
         } catch (e: Exception) {


### PR DESCRIPTION
Hi,

I wasn't looking closely enough and missed a return type mismatch. I made `tryIgnoringException` generic since there's no requirement on String there.

Thanks!